### PR TITLE
Fixing patch file for x3270 3.4ga9

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ I found py3270 pretty rough and ended up wrapping some of it. I've provided this
 Shouts
 ------
 
-* Thanks to Soldier of Fortran (@mainframed) for the help figuring out this mainframe stuff.
+* Thanks to Soldier of Fortran (@mainframed767) for the help figuring out this mainframe stuff.
 * Andreas Lindh (@addelindh) for the clever name of the tool.
 * Rogan Dawes for sitting opposite me for most of the writing the tool, always with helpful pointers.
 * An unnamed client who gave me the opportunity to test their mainframes and develop the tool.

--- a/x3270-hack-editprotected.patch
+++ b/x3270-hack-editprotected.patch
@@ -1,22 +1,8 @@
-Common subdirectories: x3270-3.3/Examples and x3270-3.3-hacked/Examples
-Common subdirectories: x3270-3.3/Playback and x3270-3.3-hacked/Playback
-diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
---- x3270-3.3/ctlr.c	2013-07-11 17:03:24.000000000 -0500
-+++ x3270-3.3-hacked/ctlr.c	2013-11-22 15:30:50.000000000 -0600
-@@ -334,8 +334,10 @@
- 		ea_buf[-1].fa = FA_PRINTABLE | FA_MODIFY;
- 		aea_buf[-1].fa = FA_PRINTABLE | FA_MODIFY;
- 	} else {
--		ea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
--		aea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		//ea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		ea_buf[-1].fa = FA_PRINTABLE;
-+		//aea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		aea_buf[-1].fa = FA_PRINTABLE;
- 	}
- 	if (!IN_3270 || (IN_SSCP && (kybdlock & KL_OIA_TWAIT))) {
- 		kybdlock_clr(KL_OIA_TWAIT, "ctlr_connect");
-@@ -454,7 +456,7 @@
+diff --git lib/3270/ctlr.c lib/3270/ctlr.c
+index d45beb9..38221b5 100644
+--- lib/3270/ctlr.c
++++ lib/3270/ctlr.c
+@@ -474,7 +474,7 @@ next_unprotected(int baddr0)
  		baddr = nbaddr;
  		INC_BA(nbaddr);
  		if (ea_buf[baddr].fa &&
@@ -25,8 +11,8 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  		    !ea_buf[nbaddr].fa)
  			return nbaddr;
  	} while (nbaddr != baddr0);
-@@ -1159,7 +1161,7 @@
- 		f = False;
+@@ -1171,7 +1171,7 @@ ctlr_erase_all_unprotected(void)
+ 		f = false;
  		do {
  			fa = ea_buf[baddr].fa;
 -			if (!FA_IS_PROTECTED(fa)) {
@@ -34,7 +20,7 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  				mdt_clear(baddr);
  				do {
  					INC_BA(baddr);
-@@ -1171,12 +1173,12 @@
+@@ -1183,12 +1183,12 @@ ctlr_erase_all_unprotected(void)
  						ctlr_add(baddr, EBC_null, 0);
  					}
  				} while (!ea_buf[baddr].fa);
@@ -46,26 +32,26 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
 -			}
 +			//}
 +			//else {
-+				//do {
-+					//INC_BA(baddr);
-+				//} while (!ea_buf[baddr].fa);
++			//	do {
++			//		INC_BA(baddr);
++			//	} while (!ea_buf[baddr].fa);
 +			//}
  		} while (baddr != sbaddr);
  		if (!f)
  			cursor_move(0);
-@@ -1346,8 +1348,9 @@
+@@ -1356,8 +1356,9 @@ ctlr_write(unsigned char buf[], int buflen, bool erase)
  			 * of an unprotected field, simply advance one
  			 * position.
  			 */
 -			if (ea_buf[buffer_addr].fa &&
 -			    !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
-+			if (ea_buf[buffer_addr].fa) {
 +			//if (ea_buf[buffer_addr].fa &&
-+			 //   !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
++			//    !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
++			if (ea_buf[buffer_addr].fa) {
  				INC_BA(buffer_addr);
- 				last_zpt = False;
- 				last_cmd = True;
-@@ -1512,7 +1515,8 @@
+ 				last_zpt = false;
+ 				last_cmd = true;
+@@ -1519,7 +1520,8 @@ ctlr_write(unsigned char buf[], int buflen, bool erase)
  			do {
  				if (ea_buf[buffer_addr].fa)
  					current_fa = ea_buf[buffer_addr].fa;
@@ -75,79 +61,95 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  					ctlr_add(buffer_addr, EBC_null,
  					    CS_BASE);
  				}
-diff -u x3270-3.3/fprint_screen.c x3270-3.3-hacked/fprint_screen.c
---- x3270-3.3/fprint_screen.c	2013-07-11 17:03:24.000000000 -0500
-+++ x3270-3.3-hacked/fprint_screen.c	2013-11-22 15:42:53.000000000 -0600
-@@ -80,7 +80,8 @@
+diff --git lib/3270/fprint_screen.c lib/3270/fprint_screen.c
+index 44b4910..ed59945 100644
+--- lib/3270/fprint_screen.c
++++ lib/3270/fprint_screen.c
+@@ -79,7 +79,8 @@ color_from_fa(unsigned char fa)
  		HOST_COLOR_BLUE,         /* protected */
  		HOST_COLOR_WHITE         /* protected, intensified */
  #       define DEFCOLOR_MAP(f) \
 -		((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
-+		(((f) & FA_INT_HIGH_SEL) >> 3)
-+		//((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
++			(((f) & FA_INT_HIGH_SEL) >> 3)
++			//((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
  	};
  
  	if (appres.m3279)
-Common subdirectories: x3270-3.3/ft and x3270-3.3-hacked/ft
-Common subdirectories: x3270-3.3/html and x3270-3.3-hacked/html
-diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
---- x3270-3.3/kybd.c	2013-07-11 17:03:24.000000000 -0500
-+++ x3270-3.3-hacked/kybd.c	2013-11-22 15:39:37.000000000 -0600
-@@ -830,10 +830,10 @@
- 	baddr = cursor_addr;
- 	faddr = find_field_attribute(baddr);
- 	fa = get_field_attribute(baddr);
+diff --git lib/3270/kybd.c lib/3270/kybd.c
+index 81aefe0..32da414 100644
+--- lib/3270/kybd.c
++++ lib/3270/kybd.c
+@@ -994,20 +994,20 @@ key_Character(unsigned ebc, bool with_ge, bool pasting)
+ 	    auto_skip = false;
+ 	}
+ 
 -	if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
--		operator_error(KL_OERR_PROTECTED);
--		return False;
--	}
+-	    if (!auto_skip) {
 +	//if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//    if (!auto_skip) {
+ 		/*
+ 		 * In overlay-paste mode, protected fields cause paste buffer
+ 		 * data to be dropped while moving the cursor right.
+ 		 */
+-		INC_BA(baddr);
+-		cursor_move(baddr);
+-		return true;
+-	    } else {
+-		operator_error(KL_OERR_PROTECTED);
+-		return false;
+-	    }
+-	}
++	//	INC_BA(baddr);
++	//	cursor_move(baddr);
++	//	return true;
++	//    } else {
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
++	//    }
 +	//}
  	if (appres.numeric_lock && FA_IS_NUMERIC(fa) &&
- 	    !((code >= EBC_0 && code <= EBC_9) ||
- 	      code == EBC_minus || code == EBC_period)) {
-@@ -1121,10 +1121,10 @@
+ 	    !((ebc >= EBC_0 && ebc <= EBC_9) ||
+ 	      ebc == EBC_minus || ebc == EBC_period)) {
+@@ -1280,10 +1280,10 @@ key_WCharacter(unsigned char ebc_pair[])
  	faddr = find_field_attribute(baddr);
  
  	/* Protected? */
 -	if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
 -		operator_error(KL_OERR_PROTECTED);
--		return False;
+-		return false;
 -	}
 +	//if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
 +	//}
  
  	/* Numeric? */
  	if (appres.numeric_lock && FA_IS_NUMERIC(fa)) {
-@@ -1598,7 +1598,7 @@
- 		nbaddr = baddr;
- 		INC_BA(nbaddr);
- 		if (ea_buf[baddr].fa &&
--		    !FA_IS_PROTECTED(ea_buf[baddr].fa) &&
-+		    //!FA_IS_PROTECTED(ea_buf[baddr].fa) &&
- 		    !ea_buf[nbaddr].fa)
- 			break;
- 		DEC_BA(baddr);
-@@ -1813,10 +1813,10 @@
+@@ -1738,7 +1738,7 @@ BackTab_action(ia_t ia, unsigned argc, const char **argv)
+ 	nbaddr = baddr;
+ 	INC_BA(nbaddr);
+ 	if (ea_buf[baddr].fa &&
+-	    !FA_IS_PROTECTED(ea_buf[baddr].fa) &&
++	    //!FA_IS_PROTECTED(ea_buf[baddr].fa) &&
+ 	    !ea_buf[nbaddr].fa) {
+ 	    break;
+ 	}
+@@ -1951,10 +1951,10 @@ do_delete(void)
  
  	/* Can't delete a field attribute. */
  	fa = get_field_attribute(baddr);
 -	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
 -		operator_error(KL_OERR_PROTECTED);
--		return False;
+-		return false;
 -	}
 +	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
 +	//}
  	if (ea_buf[baddr].cc == EBC_so || ea_buf[baddr].cc == EBC_si) {
  		/*
  		 * Can't delete SO or SI, unless it's adjacent to its
-@@ -1948,10 +1948,10 @@
+@@ -2090,10 +2090,10 @@ do_erase(void)
  
  	baddr = cursor_addr;
  	faddr = find_field_attribute(baddr);
@@ -156,41 +158,31 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
 -		return;
 -	}
 +	//if (faddr == baddr || FA_IS_PROTECTED(ea_buf[baddr].fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return;
 +	//}
  	if (baddr && faddr == baddr - 1)
  		return;
  	do_left();
-@@ -2125,7 +2125,7 @@
- 	prot = FA_IS_PROTECTED(get_field_attribute(baddr));
+@@ -2275,7 +2275,7 @@ PreviousWord_action(ia_t ia, unsigned argc, const char **argv)
+     prot = FA_IS_PROTECTED(get_field_attribute(baddr));
  
- 	/* Skip to before this word, if in one now. */
--	if (!prot) {
-+	//if (!prot) {
- 		c = ea_buf[baddr].cc;
- 		while (!ea_buf[baddr].fa && c != EBC_space && c != EBC_null) {
- 			DEC_BA(baddr);
-@@ -2133,7 +2133,7 @@
- 				return;
- 			c = ea_buf[baddr].cc;
- 		}
--	}
-+	//}
- 	baddr0 = baddr;
+     /* Skip to before this word, if in one now. */
+-    if (!prot) {
++   // if (!prot) {
+ 	c = ea_buf[baddr].cc;
+ 	while (!ea_buf[baddr].fa && c != EBC_space && c != EBC_null) {
+ 	    DEC_BA(baddr);
+@@ -2284,7 +2284,7 @@ PreviousWord_action(ia_t ia, unsigned argc, const char **argv)
+ 	    }
+ 	    c = ea_buf[baddr].cc;
+ 	}
+-    }
++   // }
+     baddr0 = baddr;
  
- 	/* Find the end of the preceding word. */
-@@ -2144,7 +2144,8 @@
- 			prot = FA_IS_PROTECTED(get_field_attribute(baddr));
- 			continue;
- 		}
--		if (!prot && c != EBC_space && c != EBC_null)
-+		//if (!prot && c != EBC_space && c != EBC_null)
-+		if (c != EBC_space && c != EBC_null)
- 			break;
- 		DEC_BA(baddr);
- 	} while (baddr != baddr0);
-@@ -2217,7 +2218,8 @@
+     /* Find the end of the preceding word. */
+@@ -2375,7 +2375,8 @@ nu_word(int baddr)
  		c = ea_buf[baddr].cc;
  		if (ea_buf[baddr].fa)
  			prot = FA_IS_PROTECTED(ea_buf[baddr].fa);
@@ -200,160 +192,160 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
  			return baddr;
  		INC_BA(baddr);
  	} while (baddr != baddr0);
-@@ -2274,13 +2276,13 @@
- 		return;
+@@ -2432,14 +2433,14 @@ NextWord_action(ia_t ia, unsigned argc, const char **argv)
+     }
  
- 	/* If not in an unprotected field, go to the next unprotected word. */
--	if (ea_buf[cursor_addr].fa ||
--	    FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
--		baddr = nu_word(cursor_addr);
--		if (baddr != -1)
--			cursor_move(baddr);
--		return;
+     /* If not in an unprotected field, go to the next unprotected word. */
+-    if (ea_buf[cursor_addr].fa ||
+-	FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
+-	baddr = nu_word(cursor_addr);
+-	if (baddr != -1) {
+-	    cursor_move(baddr);
 -	}
-+	//if (ea_buf[cursor_addr].fa ||
-+	    //FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
-+		//baddr = nu_word(cursor_addr);
-+		//if (baddr != -1)
-+			//cursor_move(baddr);
-+		//return;
+-	return true;
+-    }
++   // if (ea_buf[cursor_addr].fa ||
++	//FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
++	//baddr = nu_word(cursor_addr);
++	//if (baddr != -1) {
++	//    cursor_move(baddr);
 +	//}
++	//return true;
++   // }
  
- 	/* If there's another word in this field, go to it. */
- 	baddr = nt_word(cursor_addr);
-@@ -2405,7 +2407,8 @@
- 	baddr = (baddr / COLS) * COLS;			/* 1st col */
- 	faddr = find_field_attribute(baddr);
- 	fa = ea_buf[faddr].fa;
--	if (faddr != baddr && !FA_IS_PROTECTED(fa))
-+	//if (faddr != baddr && !FA_IS_PROTECTED(fa))
-+	if (faddr != baddr)
- 		cursor_move(baddr);
- 	else
- 		cursor_move(next_unprotected(baddr));
-@@ -2689,10 +2692,10 @@
- #endif /*]*/
- 	baddr = cursor_addr;
- 	fa = get_field_attribute(baddr);
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
- 	if (formatted) {	/* erase to next field attribute */
+     /* If there's another word in this field, go to it. */
+     baddr = nt_word(cursor_addr);
+@@ -2570,7 +2571,8 @@ Newline_action(ia_t ia, unsigned argc, const char **argv)
+     baddr = (baddr / COLS) * COLS;			/* 1st col */
+     faddr = find_field_attribute(baddr);
+     fa = ea_buf[faddr].fa;
+-    if (faddr != baddr && !FA_IS_PROTECTED(fa)) {
++    ///if (faddr != baddr && !FA_IS_PROTECTED(fa)) {
++	 if (faddr != baddr) {
+ 	cursor_move(baddr);
+     } else {
+ 	cursor_move(next_unprotected(baddr));
+@@ -2836,10 +2838,10 @@ EraseEOF_action(ia_t ia, unsigned argc, const char **argv)
+     }
+     baddr = cursor_addr;
+     fa = get_field_attribute(baddr);
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++    //if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   // }
+     if (formatted) {	/* erase to next field attribute */
+ 	do {
+ 	    ctlr_add(baddr, EBC_null, 0);
+@@ -2904,7 +2906,7 @@ EraseInput_action(ia_t ia, unsigned argc, const char **argv)
+ 	f = false;
+ 	do {
+ 	    fa = ea_buf[baddr].fa;
+-	    if (!FA_IS_PROTECTED(fa)) {
++	   // if (!FA_IS_PROTECTED(fa)) {
+ 		mdt_clear(baddr);
  		do {
+ 		    INC_BA(baddr);
+@@ -2916,11 +2918,11 @@ EraseInput_action(ia_t ia, unsigned argc, const char **argv)
  			ctlr_add(baddr, EBC_null, 0);
-@@ -2754,7 +2757,7 @@
- 		f = False;
- 		do {
- 			fa = ea_buf[baddr].fa;
--			if (!FA_IS_PROTECTED(fa)) {
-+			//if (!FA_IS_PROTECTED(fa)) {
- 				mdt_clear(baddr);
- 				do {
- 					INC_BA(baddr);
-@@ -2766,11 +2769,11 @@
- 						ctlr_add(baddr, EBC_null, 0);
- 					}
- 				} while (!ea_buf[baddr].fa);
--			} else {	/* skip protected */
--				do {
--					INC_BA(baddr);
--				} while (!ea_buf[baddr].fa);
--			}
-+			//} else {	/* skip protected */
-+				//do {
-+					//INC_BA(baddr);
-+				//} while (!ea_buf[baddr].fa);
-+			//}
- 		} while (baddr != sbaddr);
- 		if (!f)
- 			cursor_move(0);
-@@ -2816,10 +2819,10 @@
- 	fa = get_field_attribute(baddr);
+ 		    }
+ 		} while (!ea_buf[baddr].fa);
+-	    } else {	/* skip protected */
+-		do {
+-		    INC_BA(baddr);
+-		} while (!ea_buf[baddr].fa);
+-	    }
++	    //} else {	/* skip protected */
++		//do {
++		//    INC_BA(baddr);
++		//} while (!ea_buf[baddr].fa);
++	   // }
+ 	} while (baddr != sbaddr);
+ 	if (!f) {
+ 	    cursor_move(0);
+@@ -2971,10 +2973,10 @@ DeleteWord_action(ia_t ia, unsigned argc, const char **argv)
+     fa = get_field_attribute(baddr);
  
- 	/* Make sure we're on a modifiable field. */
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
+     /* Make sure we're on a modifiable field. */
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++   // if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   //}
  
- 	/* Backspace over any spaces to the left of the cursor. */
- 	for (;;) {
-@@ -2882,10 +2885,10 @@
+     /* Backspace over any spaces to the left of the cursor. */
+     for (;;) {
+@@ -3040,10 +3042,10 @@ DeleteField_action(ia_t ia, unsigned argc, const char **argv)
  
- 	baddr = cursor_addr;
- 	fa = get_field_attribute(baddr);
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
- 	while (!ea_buf[baddr].fa)
- 		DEC_BA(baddr);
- 	INC_BA(baddr);
-@@ -2996,8 +2999,8 @@
- 	baddr = cursor_addr;
- 	faddr = find_field_attribute(baddr);
- 	fa = ea_buf[faddr].fa;
--	if (faddr == baddr || FA_IS_PROTECTED(fa))
--		return;
-+	//if (faddr == baddr || FA_IS_PROTECTED(fa))
-+		//return;
+     baddr = cursor_addr;
+     fa = get_field_attribute(baddr);
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++   // if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   // }
+     while (!ea_buf[baddr].fa) {
+ 	DEC_BA(baddr);
+     }
+@@ -3160,9 +3162,9 @@ FieldEnd_action(ia_t ia, unsigned argc, const char **argv)
+     baddr = cursor_addr;
+     faddr = find_field_attribute(baddr);
+     fa = ea_buf[faddr].fa;
+-    if (faddr == baddr || FA_IS_PROTECTED(fa)) {
+-	return true;
+-    }
++   // if (faddr == baddr || FA_IS_PROTECTED(fa)) {
++	//return true;
++   // }
  
- 	baddr = faddr;
- 	while (True) {
-@@ -3336,11 +3339,11 @@
+     baddr = faddr;
+     while (true) {
+@@ -3444,11 +3446,11 @@ remargin(int lmargin)
  		}
  		faddr = find_field_attribute(baddr);
  		fa = ea_buf[faddr].fa;
 -		if (faddr == baddr || FA_IS_PROTECTED(fa)) {
 -			baddr = next_unprotected(baddr);
 -			if (baddr <= b0)
--				return False;
+-				return false;
 -		}
 +		//if (faddr == baddr || FA_IS_PROTECTED(fa)) {
-+			//baddr = next_unprotected(baddr);
-+			//if (baddr <= b0)
-+				//return False;
++		//	baddr = next_unprotected(baddr);
++		//	if (baddr <= b0)
++		//		return false;
 +		//}
  	}
  
  	cursor_move(baddr);
-@@ -3947,26 +3950,26 @@
- 		return 0;
+@@ -4058,27 +4060,27 @@ kybd_prime(void)
+ 	}
  
  	fa = get_field_attribute(cursor_addr);
 -	if (ea_buf[cursor_addr].fa || FA_IS_PROTECTED(fa)) {
--		/*
--		 * The cursor is not in an unprotected field.  Find the
--		 * next one.
--		 */
--		baddr = next_unprotected(cursor_addr);
--
--		/* If there isn't any, give up. */
--		if (!baddr)
--			return 0;
 +	//if (ea_buf[cursor_addr].fa || FA_IS_PROTECTED(fa)) {
-+		///*
-+		 //* The cursor is not in an unprotected field.  Find the
-+		 //* next one.
-+		 //*/
-+		//baddr = next_unprotected(cursor_addr);
-+
-+		///* If there isn't any, give up. */
-+		//if (!baddr)
-+			//return 0;
+ 		/*
+ 		 * The cursor is not in an unprotected field.  Find the
+ 		 * next one.
+ 		 */
+-		baddr = next_unprotected(cursor_addr);
++	//	baddr = next_unprotected(cursor_addr);
+ 
+ 		/* If there isn't any, give up. */
+-		if (!baddr) {
+-			return 0;
+-		}
++	//	if (!baddr) {
++	//		return 0;
++	//	}
  
  		/* Move the cursor there. */
 -	} else {
@@ -369,48 +361,37 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
  
  	/* Move the cursor to the beginning of the field. */
  	cursor_move(baddr);
-diff -u x3270-3.3/macros.c x3270-3.3-hacked/macros.c
---- x3270-3.3/macros.c	2013-07-24 17:02:10.000000000 -0500
-+++ x3270-3.3-hacked/macros.c	2013-11-22 15:39:57.000000000 -0600
-@@ -2498,9 +2498,9 @@
- 		unsigned char fa;
+diff --git lib/3270/macros.c lib/3270/macros.c
+index 9c707c0..e05c96b 100644
+--- lib/3270/macros.c
++++ lib/3270/macros.c
+@@ -2611,11 +2611,11 @@ status_string(void)
+ 	unsigned char fa;
  
- 		fa = get_field_attribute(cursor_addr);
--		if (FA_IS_PROTECTED(fa))
--			prot_stat = 'P';
--		else
-+		//if (FA_IS_PROTECTED(fa))
-+			//prot_stat = 'P';
-+		//else
- 			prot_stat = 'U';
- 	}
+ 	fa = get_field_attribute(cursor_addr);
+-	if (FA_IS_PROTECTED(fa)) {
+-	    prot_stat = 'P';
+-	} else {
++	//if (FA_IS_PROTECTED(fa)) {
++	//    prot_stat = 'P';
++	//} else {
+ 	    prot_stat = 'U';
+-	}
++	//}
+     }
  
-diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
---- x3270-3.3/screen.c	2013-09-06 09:59:02.000000000 -0500
-+++ x3270-3.3-hacked/screen.c	2013-11-22 15:31:41.000000000 -0600
-@@ -2403,9 +2403,10 @@
- 			else
- 				field_color = fa_color(fa);
- 			if (visible_control) {
--				if (FA_IS_PROTECTED(fa))
--					b.bits.cc = EBC_P;
--				else if (FA_IS_MODIFIED(fa))
-+				//if (FA_IS_PROTECTED(fa))
-+					//b.bits.cc = EBC_P;
-+				//else if (FA_IS_MODIFIED(fa))
-+				if (FA_IS_MODIFIED(fa))
- 					b.bits.cc = EBC_M;
- 				else
- 					b.bits.cc = EBC_U;
-diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
---- x3270-3.3/select.c	2013-07-11 17:03:27.000000000 -0500
-+++ x3270-3.3-hacked/select.c	2013-11-22 15:32:15.000000000 -0600
-@@ -820,7 +820,8 @@
- 	for (baddr = 0; baddr < ROWS*COLS; baddr++) {
- 		if (ea_buf[baddr].fa)
- 			fa = ea_buf[baddr].fa;
--		else if ((IN_ANSI || !FA_IS_PROTECTED(fa)) && SELECTED(baddr))
-+		//else if ((IN_ANSI || !FA_IS_PROTECTED(fa)) && SELECTED(baddr))
-+		else if (IN_ANSI && SELECTED(baddr))
- 			target[baddr/ULBS] |= 1 << (baddr%ULBS);
+     if (CONNECTED) {
+diff --git x3270/select.c x3270/select.c
+index 3b4a3b9..192eaf0 100644
+--- x3270/select.c
++++ x3270/select.c
+@@ -863,7 +863,8 @@ Cut_xaction(Widget w _is_unused, XEvent *event, String *params,
+     for (baddr = 0; baddr < ROWS*COLS; baddr++) {
+ 	if (ea_buf[baddr].fa) {
+ 	    fa = ea_buf[baddr].fa;
+-	} else if ((IN_NVT || !FA_IS_PROTECTED(fa)) && screen_selected(baddr)) {
++	//} else if ((IN_NVT || !FA_IS_PROTECTED(fa)) && screen_selected(baddr)) {
++	} 	else if (IN_NVT && screen_selected(baddr))  {
+ 	    target[baddr/ULBS] |= 1L << (baddr%ULBS);
  	}
+     }

--- a/x3270-hack-full.patch
+++ b/x3270-hack-full.patch
@@ -1,20 +1,8 @@
-diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
---- x3270-3.3/ctlr.c	2013-07-12 00:03:24.000000000 +0200
-+++ x3270-3.3-hacked/ctlr.c	2013-12-16 23:51:46.000000000 +0200
-@@ -334,8 +334,10 @@
- 		ea_buf[-1].fa = FA_PRINTABLE | FA_MODIFY;
- 		aea_buf[-1].fa = FA_PRINTABLE | FA_MODIFY;
- 	} else {
--		ea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
--		aea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		//ea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		ea_buf[-1].fa = FA_PRINTABLE;
-+		//aea_buf[-1].fa = FA_PRINTABLE | FA_PROTECT;
-+		aea_buf[-1].fa = FA_PRINTABLE;
- 	}
- 	if (!IN_3270 || (IN_SSCP && (kybdlock & KL_OIA_TWAIT))) {
- 		kybdlock_clr(KL_OIA_TWAIT, "ctlr_connect");
-@@ -454,7 +456,7 @@
+diff --git lib/3270/ctlr.c lib/3270/ctlr.c
+index d45beb9..38221b5 100644
+--- lib/3270/ctlr.c
++++ lib/3270/ctlr.c
+@@ -474,7 +474,7 @@ next_unprotected(int baddr0)
  		baddr = nbaddr;
  		INC_BA(nbaddr);
  		if (ea_buf[baddr].fa &&
@@ -23,8 +11,8 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  		    !ea_buf[nbaddr].fa)
  			return nbaddr;
  	} while (nbaddr != baddr0);
-@@ -1159,7 +1161,7 @@
- 		f = False;
+@@ -1171,7 +1171,7 @@ ctlr_erase_all_unprotected(void)
+ 		f = false;
  		do {
  			fa = ea_buf[baddr].fa;
 -			if (!FA_IS_PROTECTED(fa)) {
@@ -32,7 +20,7 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  				mdt_clear(baddr);
  				do {
  					INC_BA(baddr);
-@@ -1171,12 +1173,12 @@
+@@ -1183,12 +1183,12 @@ ctlr_erase_all_unprotected(void)
  						ctlr_add(baddr, EBC_null, 0);
  					}
  				} while (!ea_buf[baddr].fa);
@@ -44,26 +32,26 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
 -			}
 +			//}
 +			//else {
-+				//do {
-+					//INC_BA(baddr);
-+				//} while (!ea_buf[baddr].fa);
++			//	do {
++			//		INC_BA(baddr);
++			//	} while (!ea_buf[baddr].fa);
 +			//}
  		} while (baddr != sbaddr);
  		if (!f)
  			cursor_move(0);
-@@ -1346,8 +1348,9 @@
+@@ -1356,8 +1356,9 @@ ctlr_write(unsigned char buf[], int buflen, bool erase)
  			 * of an unprotected field, simply advance one
  			 * position.
  			 */
 -			if (ea_buf[buffer_addr].fa &&
 -			    !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
-+			if (ea_buf[buffer_addr].fa) {
 +			//if (ea_buf[buffer_addr].fa &&
-+			 //   !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
++			//    !FA_IS_PROTECTED(ea_buf[buffer_addr].fa)) {
++			if (ea_buf[buffer_addr].fa) {
  				INC_BA(buffer_addr);
- 				last_zpt = False;
- 				last_cmd = True;
-@@ -1512,7 +1515,8 @@
+ 				last_zpt = false;
+ 				last_cmd = true;
+@@ -1519,7 +1520,8 @@ ctlr_write(unsigned char buf[], int buflen, bool erase)
  			do {
  				if (ea_buf[buffer_addr].fa)
  					current_fa = ea_buf[buffer_addr].fa;
@@ -73,122 +61,95 @@ diff -u x3270-3.3/ctlr.c x3270-3.3-hacked/ctlr.c
  					ctlr_add(buffer_addr, EBC_null,
  					    CS_BASE);
  				}
-diff -u x3270-3.3/fprint_screen.c x3270-3.3-hacked/fprint_screen.c
---- x3270-3.3/fprint_screen.c	2013-07-12 00:03:24.000000000 +0200
-+++ x3270-3.3-hacked/fprint_screen.c	2014-05-28 00:49:38.000000000 +0200
-@@ -80,7 +80,8 @@
+diff --git lib/3270/fprint_screen.c lib/3270/fprint_screen.c
+index 44b4910..ed59945 100644
+--- lib/3270/fprint_screen.c
++++ lib/3270/fprint_screen.c
+@@ -79,7 +79,8 @@ color_from_fa(unsigned char fa)
  		HOST_COLOR_BLUE,         /* protected */
  		HOST_COLOR_WHITE         /* protected, intensified */
  #       define DEFCOLOR_MAP(f) \
 -		((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
-+		(((f) & FA_INT_HIGH_SEL) >> 3)
-+		//((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
++			(((f) & FA_INT_HIGH_SEL) >> 3)
++			//((((f) & FA_PROTECT) >> 4) | (((f) & FA_INT_HIGH_SEL) >> 3))
  	};
  
  	if (appres.m3279)
-@@ -360,6 +361,7 @@
- 	unsigned char fa = ea_buf[fa_addr].fa;
- 	int fa_fg, current_fg;
- 	int fa_bg, current_bg;
-+	int fa_zero = 0;
- 	Bool fa_high, current_high;
- 	Bool fa_ital, current_ital;
- 	Bool mi;
-@@ -465,13 +467,21 @@
- 			fa_ital = mi && FA_IS_MODIFIED(fa);
- 		}
- 		if (FA_IS_ZERO(fa)) {
--#if defined(X3270_DBCS) /*[*/
--			if (ctlr_dbcs_state(i) == DBCS_LEFT)
--			    	uc = 0x3000;
--			else
--#endif /*]*/
--				uc = ' ';
-+//#if defined(X3270_DBCS) /*[*/
-+			//if (ctlr_dbcs_state(i) == DBCS_LEFT)
-+			    	//uc = 0x3000;
-+			//else
-+//#endif /*]*/
-+				if (fa_zero > 0) { //invert colours for hidden fields
-+					fa_zero = fa_fg;
-+					fa_fg = fa_bg;
-+					fa_bg = fa_zero;
-+					fa_zero = -1;
-+				}
-+				//uc = ' ';
- 		} else {
-+			fa_zero = 1; //unset the flag
-+		}
- 		    	/* Convert EBCDIC to Unicode. */
- #if defined(X3270_DBCS) /*[*/
- 			switch (ctlr_dbcs_state(i)) {
-@@ -503,7 +513,7 @@
- 			if (uc == 0)
- 				uc = ' ';
- #endif /*]*/
--		}
-+		//}
+diff --git lib/3270/kybd.c lib/3270/kybd.c
+index 81aefe0..32da414 100644
+--- lib/3270/kybd.c
++++ lib/3270/kybd.c
+@@ -994,20 +994,20 @@ key_Character(unsigned ebc, bool with_ge, bool pasting)
+ 	    auto_skip = false;
+ 	}
  
- 		/* Translate to a type-specific format and write it out. */
- 		if (uc == ' ' && fps->ptype != P_HTML)
-diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
---- x3270-3.3/kybd.c	2013-07-12 00:03:24.000000000 +0200
-+++ x3270-3.3-hacked/kybd.c	2013-12-16 23:51:46.000000000 +0200
-@@ -830,10 +830,10 @@
- 	baddr = cursor_addr;
- 	faddr = find_field_attribute(baddr);
- 	fa = get_field_attribute(baddr);
 -	if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
--		operator_error(KL_OERR_PROTECTED);
--		return False;
--	}
+-	    if (!auto_skip) {
 +	//if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//    if (!auto_skip) {
+ 		/*
+ 		 * In overlay-paste mode, protected fields cause paste buffer
+ 		 * data to be dropped while moving the cursor right.
+ 		 */
+-		INC_BA(baddr);
+-		cursor_move(baddr);
+-		return true;
+-	    } else {
+-		operator_error(KL_OERR_PROTECTED);
+-		return false;
+-	    }
+-	}
++	//	INC_BA(baddr);
++	//	cursor_move(baddr);
++	//	return true;
++	//    } else {
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
++	//    }
 +	//}
  	if (appres.numeric_lock && FA_IS_NUMERIC(fa) &&
- 	    !((code >= EBC_0 && code <= EBC_9) ||
- 	      code == EBC_minus || code == EBC_period)) {
-@@ -1121,10 +1121,10 @@
+ 	    !((ebc >= EBC_0 && ebc <= EBC_9) ||
+ 	      ebc == EBC_minus || ebc == EBC_period)) {
+@@ -1280,10 +1280,10 @@ key_WCharacter(unsigned char ebc_pair[])
  	faddr = find_field_attribute(baddr);
  
  	/* Protected? */
 -	if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
 -		operator_error(KL_OERR_PROTECTED);
--		return False;
+-		return false;
 -	}
 +	//if (ea_buf[baddr].fa || FA_IS_PROTECTED(fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
 +	//}
  
  	/* Numeric? */
  	if (appres.numeric_lock && FA_IS_NUMERIC(fa)) {
-@@ -1598,7 +1598,7 @@
- 		nbaddr = baddr;
- 		INC_BA(nbaddr);
- 		if (ea_buf[baddr].fa &&
--		    !FA_IS_PROTECTED(ea_buf[baddr].fa) &&
-+		    //!FA_IS_PROTECTED(ea_buf[baddr].fa) &&
- 		    !ea_buf[nbaddr].fa)
- 			break;
- 		DEC_BA(baddr);
-@@ -1813,10 +1813,10 @@
+@@ -1738,7 +1738,7 @@ BackTab_action(ia_t ia, unsigned argc, const char **argv)
+ 	nbaddr = baddr;
+ 	INC_BA(nbaddr);
+ 	if (ea_buf[baddr].fa &&
+-	    !FA_IS_PROTECTED(ea_buf[baddr].fa) &&
++	    //!FA_IS_PROTECTED(ea_buf[baddr].fa) &&
+ 	    !ea_buf[nbaddr].fa) {
+ 	    break;
+ 	}
+@@ -1951,10 +1951,10 @@ do_delete(void)
  
  	/* Can't delete a field attribute. */
  	fa = get_field_attribute(baddr);
 -	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
 -		operator_error(KL_OERR_PROTECTED);
--		return False;
+-		return false;
 -	}
 +	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return False;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return false;
 +	//}
  	if (ea_buf[baddr].cc == EBC_so || ea_buf[baddr].cc == EBC_si) {
  		/*
  		 * Can't delete SO or SI, unless it's adjacent to its
-@@ -1948,10 +1948,10 @@
+@@ -2090,10 +2090,10 @@ do_erase(void)
  
  	baddr = cursor_addr;
  	faddr = find_field_attribute(baddr);
@@ -197,41 +158,31 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
 -		return;
 -	}
 +	//if (faddr == baddr || FA_IS_PROTECTED(ea_buf[baddr].fa)) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
++	//	operator_error(KL_OERR_PROTECTED);
++	//	return;
 +	//}
  	if (baddr && faddr == baddr - 1)
  		return;
  	do_left();
-@@ -2125,7 +2125,7 @@
- 	prot = FA_IS_PROTECTED(get_field_attribute(baddr));
+@@ -2275,7 +2275,7 @@ PreviousWord_action(ia_t ia, unsigned argc, const char **argv)
+     prot = FA_IS_PROTECTED(get_field_attribute(baddr));
  
- 	/* Skip to before this word, if in one now. */
--	if (!prot) {
-+	//if (!prot) {
- 		c = ea_buf[baddr].cc;
- 		while (!ea_buf[baddr].fa && c != EBC_space && c != EBC_null) {
- 			DEC_BA(baddr);
-@@ -2133,7 +2133,7 @@
- 				return;
- 			c = ea_buf[baddr].cc;
- 		}
--	}
-+	//}
- 	baddr0 = baddr;
+     /* Skip to before this word, if in one now. */
+-    if (!prot) {
++   // if (!prot) {
+ 	c = ea_buf[baddr].cc;
+ 	while (!ea_buf[baddr].fa && c != EBC_space && c != EBC_null) {
+ 	    DEC_BA(baddr);
+@@ -2284,7 +2284,7 @@ PreviousWord_action(ia_t ia, unsigned argc, const char **argv)
+ 	    }
+ 	    c = ea_buf[baddr].cc;
+ 	}
+-    }
++   // }
+     baddr0 = baddr;
  
- 	/* Find the end of the preceding word. */
-@@ -2144,7 +2144,8 @@
- 			prot = FA_IS_PROTECTED(get_field_attribute(baddr));
- 			continue;
- 		}
--		if (!prot && c != EBC_space && c != EBC_null)
-+		//if (!prot && c != EBC_space && c != EBC_null)
-+		if (c != EBC_space && c != EBC_null)
- 			break;
- 		DEC_BA(baddr);
- 	} while (baddr != baddr0);
-@@ -2217,7 +2218,8 @@
+     /* Find the end of the preceding word. */
+@@ -2375,7 +2375,8 @@ nu_word(int baddr)
  		c = ea_buf[baddr].cc;
  		if (ea_buf[baddr].fa)
  			prot = FA_IS_PROTECTED(ea_buf[baddr].fa);
@@ -241,160 +192,160 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
  			return baddr;
  		INC_BA(baddr);
  	} while (baddr != baddr0);
-@@ -2274,13 +2276,13 @@
- 		return;
+@@ -2432,14 +2433,14 @@ NextWord_action(ia_t ia, unsigned argc, const char **argv)
+     }
  
- 	/* If not in an unprotected field, go to the next unprotected word. */
--	if (ea_buf[cursor_addr].fa ||
--	    FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
--		baddr = nu_word(cursor_addr);
--		if (baddr != -1)
--			cursor_move(baddr);
--		return;
+     /* If not in an unprotected field, go to the next unprotected word. */
+-    if (ea_buf[cursor_addr].fa ||
+-	FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
+-	baddr = nu_word(cursor_addr);
+-	if (baddr != -1) {
+-	    cursor_move(baddr);
 -	}
-+	//if (ea_buf[cursor_addr].fa ||
-+	    //FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
-+		//baddr = nu_word(cursor_addr);
-+		//if (baddr != -1)
-+			//cursor_move(baddr);
-+		//return;
+-	return true;
+-    }
++   // if (ea_buf[cursor_addr].fa ||
++	//FA_IS_PROTECTED(get_field_attribute(cursor_addr))) {
++	//baddr = nu_word(cursor_addr);
++	//if (baddr != -1) {
++	//    cursor_move(baddr);
 +	//}
++	//return true;
++   // }
  
- 	/* If there's another word in this field, go to it. */
- 	baddr = nt_word(cursor_addr);
-@@ -2405,7 +2407,8 @@
- 	baddr = (baddr / COLS) * COLS;			/* 1st col */
- 	faddr = find_field_attribute(baddr);
- 	fa = ea_buf[faddr].fa;
--	if (faddr != baddr && !FA_IS_PROTECTED(fa))
-+	//if (faddr != baddr && !FA_IS_PROTECTED(fa))
-+	if (faddr != baddr)
- 		cursor_move(baddr);
- 	else
- 		cursor_move(next_unprotected(baddr));
-@@ -2689,10 +2692,10 @@
- #endif /*]*/
- 	baddr = cursor_addr;
- 	fa = get_field_attribute(baddr);
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
- 	if (formatted) {	/* erase to next field attribute */
+     /* If there's another word in this field, go to it. */
+     baddr = nt_word(cursor_addr);
+@@ -2570,7 +2571,8 @@ Newline_action(ia_t ia, unsigned argc, const char **argv)
+     baddr = (baddr / COLS) * COLS;			/* 1st col */
+     faddr = find_field_attribute(baddr);
+     fa = ea_buf[faddr].fa;
+-    if (faddr != baddr && !FA_IS_PROTECTED(fa)) {
++    ///if (faddr != baddr && !FA_IS_PROTECTED(fa)) {
++	 if (faddr != baddr) {
+ 	cursor_move(baddr);
+     } else {
+ 	cursor_move(next_unprotected(baddr));
+@@ -2836,10 +2838,10 @@ EraseEOF_action(ia_t ia, unsigned argc, const char **argv)
+     }
+     baddr = cursor_addr;
+     fa = get_field_attribute(baddr);
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++    //if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   // }
+     if (formatted) {	/* erase to next field attribute */
+ 	do {
+ 	    ctlr_add(baddr, EBC_null, 0);
+@@ -2904,7 +2906,7 @@ EraseInput_action(ia_t ia, unsigned argc, const char **argv)
+ 	f = false;
+ 	do {
+ 	    fa = ea_buf[baddr].fa;
+-	    if (!FA_IS_PROTECTED(fa)) {
++	   // if (!FA_IS_PROTECTED(fa)) {
+ 		mdt_clear(baddr);
  		do {
+ 		    INC_BA(baddr);
+@@ -2916,11 +2918,11 @@ EraseInput_action(ia_t ia, unsigned argc, const char **argv)
  			ctlr_add(baddr, EBC_null, 0);
-@@ -2754,7 +2757,7 @@
- 		f = False;
- 		do {
- 			fa = ea_buf[baddr].fa;
--			if (!FA_IS_PROTECTED(fa)) {
-+			//if (!FA_IS_PROTECTED(fa)) {
- 				mdt_clear(baddr);
- 				do {
- 					INC_BA(baddr);
-@@ -2766,11 +2769,11 @@
- 						ctlr_add(baddr, EBC_null, 0);
- 					}
- 				} while (!ea_buf[baddr].fa);
--			} else {	/* skip protected */
--				do {
--					INC_BA(baddr);
--				} while (!ea_buf[baddr].fa);
--			}
-+			//} else {	/* skip protected */
-+				//do {
-+					//INC_BA(baddr);
-+				//} while (!ea_buf[baddr].fa);
-+			//}
- 		} while (baddr != sbaddr);
- 		if (!f)
- 			cursor_move(0);
-@@ -2816,10 +2819,10 @@
- 	fa = get_field_attribute(baddr);
+ 		    }
+ 		} while (!ea_buf[baddr].fa);
+-	    } else {	/* skip protected */
+-		do {
+-		    INC_BA(baddr);
+-		} while (!ea_buf[baddr].fa);
+-	    }
++	    //} else {	/* skip protected */
++		//do {
++		//    INC_BA(baddr);
++		//} while (!ea_buf[baddr].fa);
++	   // }
+ 	} while (baddr != sbaddr);
+ 	if (!f) {
+ 	    cursor_move(0);
+@@ -2971,10 +2973,10 @@ DeleteWord_action(ia_t ia, unsigned argc, const char **argv)
+     fa = get_field_attribute(baddr);
  
- 	/* Make sure we're on a modifiable field. */
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
+     /* Make sure we're on a modifiable field. */
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++   // if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   //}
  
- 	/* Backspace over any spaces to the left of the cursor. */
- 	for (;;) {
-@@ -2882,10 +2885,10 @@
+     /* Backspace over any spaces to the left of the cursor. */
+     for (;;) {
+@@ -3040,10 +3042,10 @@ DeleteField_action(ia_t ia, unsigned argc, const char **argv)
  
- 	baddr = cursor_addr;
- 	fa = get_field_attribute(baddr);
--	if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
--		operator_error(KL_OERR_PROTECTED);
--		return;
--	}
-+	//if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
-+		//operator_error(KL_OERR_PROTECTED);
-+		//return;
-+	//}
- 	while (!ea_buf[baddr].fa)
- 		DEC_BA(baddr);
- 	INC_BA(baddr);
-@@ -2996,8 +2999,8 @@
- 	baddr = cursor_addr;
- 	faddr = find_field_attribute(baddr);
- 	fa = ea_buf[faddr].fa;
--	if (faddr == baddr || FA_IS_PROTECTED(fa))
--		return;
-+	//if (faddr == baddr || FA_IS_PROTECTED(fa))
-+		//return;
+     baddr = cursor_addr;
+     fa = get_field_attribute(baddr);
+-    if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
+-	operator_error(KL_OERR_PROTECTED);
+-	return false;
+-    }
++   // if (FA_IS_PROTECTED(fa) || ea_buf[baddr].fa) {
++	//operator_error(KL_OERR_PROTECTED);
++	//return false;
++   // }
+     while (!ea_buf[baddr].fa) {
+ 	DEC_BA(baddr);
+     }
+@@ -3160,9 +3162,9 @@ FieldEnd_action(ia_t ia, unsigned argc, const char **argv)
+     baddr = cursor_addr;
+     faddr = find_field_attribute(baddr);
+     fa = ea_buf[faddr].fa;
+-    if (faddr == baddr || FA_IS_PROTECTED(fa)) {
+-	return true;
+-    }
++   // if (faddr == baddr || FA_IS_PROTECTED(fa)) {
++	//return true;
++   // }
  
- 	baddr = faddr;
- 	while (True) {
-@@ -3336,11 +3339,11 @@
+     baddr = faddr;
+     while (true) {
+@@ -3444,11 +3446,11 @@ remargin(int lmargin)
  		}
  		faddr = find_field_attribute(baddr);
  		fa = ea_buf[faddr].fa;
 -		if (faddr == baddr || FA_IS_PROTECTED(fa)) {
 -			baddr = next_unprotected(baddr);
 -			if (baddr <= b0)
--				return False;
+-				return false;
 -		}
 +		//if (faddr == baddr || FA_IS_PROTECTED(fa)) {
-+			//baddr = next_unprotected(baddr);
-+			//if (baddr <= b0)
-+				//return False;
++		//	baddr = next_unprotected(baddr);
++		//	if (baddr <= b0)
++		//		return false;
 +		//}
  	}
  
  	cursor_move(baddr);
-@@ -3947,26 +3950,26 @@
- 		return 0;
+@@ -4058,27 +4060,27 @@ kybd_prime(void)
+ 	}
  
  	fa = get_field_attribute(cursor_addr);
 -	if (ea_buf[cursor_addr].fa || FA_IS_PROTECTED(fa)) {
--		/*
--		 * The cursor is not in an unprotected field.  Find the
--		 * next one.
--		 */
--		baddr = next_unprotected(cursor_addr);
--
--		/* If there isn't any, give up. */
--		if (!baddr)
--			return 0;
 +	//if (ea_buf[cursor_addr].fa || FA_IS_PROTECTED(fa)) {
-+		///*
-+		 //* The cursor is not in an unprotected field.  Find the
-+		 //* next one.
-+		 //*/
-+		//baddr = next_unprotected(cursor_addr);
-+
-+		///* If there isn't any, give up. */
-+		//if (!baddr)
-+			//return 0;
+ 		/*
+ 		 * The cursor is not in an unprotected field.  Find the
+ 		 * next one.
+ 		 */
+-		baddr = next_unprotected(cursor_addr);
++	//	baddr = next_unprotected(cursor_addr);
+ 
+ 		/* If there isn't any, give up. */
+-		if (!baddr) {
+-			return 0;
+-		}
++	//	if (!baddr) {
++	//		return 0;
++	//	}
  
  		/* Move the cursor there. */
 -	} else {
@@ -410,67 +361,55 @@ diff -u x3270-3.3/kybd.c x3270-3.3-hacked/kybd.c
  
  	/* Move the cursor to the beginning of the field. */
  	cursor_move(baddr);
-diff -u x3270-3.3/macros.c x3270-3.3-hacked/macros.c
---- x3270-3.3/macros.c	2013-07-25 00:02:10.000000000 +0200
-+++ x3270-3.3-hacked/macros.c	2013-12-16 23:58:00.000000000 +0200
-@@ -2093,9 +2093,9 @@
- 			if (buf[first + i].fa) {
- 				is_zero = FA_IS_ZERO(buf[first + i].fa);
- 				s += sprintf(s, " ");
--			} else if (is_zero)
--				s += sprintf(s, " ");
--			else
-+			//} else if (is_zero) {
-+				//s += sprintf(s, " ");
-+			} else
- #if defined(X3270_DBCS) /*[*/
- 			if (IS_LEFT(ctlr_dbcs_state(first + i))) {
+diff --git lib/3270/macros.c lib/3270/macros.c
+index 7cd1ab8..e05c96b 100644
+--- lib/3270/macros.c
++++ lib/3270/macros.c
+@@ -2205,8 +2205,8 @@ dump_range(int first, int len, bool in_ascii, struct ea *buf,
+ 	    if (buf[first + i].fa) {
+ 		is_zero = FA_IS_ZERO(buf[first + i].fa);
+ 		vb_appends(&r, " ");
+-	    } else if (is_zero) {
+-		vb_appends(&r, " ");
++	   // } else if (is_zero) {
++		//vb_appends(&r, " ");
+ 	    } else if (IS_LEFT(ctlr_dbcs_state(first + i))) {
+ 		xlen = ebcdic_to_multibyte(
+ 			(buf[first + i].cc << 8) | buf[first + i + 1].cc,
+@@ -2611,11 +2611,11 @@ status_string(void)
+ 	unsigned char fa;
  
-@@ -2498,9 +2498,9 @@
- 		unsigned char fa;
+ 	fa = get_field_attribute(cursor_addr);
+-	if (FA_IS_PROTECTED(fa)) {
+-	    prot_stat = 'P';
+-	} else {
++	//if (FA_IS_PROTECTED(fa)) {
++	//    prot_stat = 'P';
++	//} else {
+ 	    prot_stat = 'U';
+-	}
++	//}
+     }
  
- 		fa = get_field_attribute(cursor_addr);
--		if (FA_IS_PROTECTED(fa))
--			prot_stat = 'P';
--		else
-+		//if (FA_IS_PROTECTED(fa))
-+			//prot_stat = 'P';
-+		//else
- 			prot_stat = 'U';
- 	}
- 
-diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
---- x3270-3.3/screen.c	2013-09-06 16:59:02.000000000 +0200
-+++ x3270-3.3-hacked/screen.c	2013-12-16 23:51:46.000000000 +0200
-@@ -2403,9 +2403,10 @@
- 			else
- 				field_color = fa_color(fa);
- 			if (visible_control) {
--				if (FA_IS_PROTECTED(fa))
--					b.bits.cc = EBC_P;
--				else if (FA_IS_MODIFIED(fa))
-+				//if (FA_IS_PROTECTED(fa))
-+					//b.bits.cc = EBC_P;
-+				//else if (FA_IS_MODIFIED(fa))
-+				if (FA_IS_MODIFIED(fa))
- 					b.bits.cc = EBC_M;
- 				else
- 					b.bits.cc = EBC_U;
-@@ -2417,9 +2418,9 @@
- 			Boolean is_vc = False;
+     if (CONNECTED) {
+diff --git x3270/screen.c x3270/screen.c
+index adbb4a9..ce2ab60 100644
+--- x3270/screen.c
++++ x3270/screen.c
+@@ -2424,9 +2424,9 @@ draw_fields(union sp *buffer, int first, int last)
+ 			bool is_vc = false;
  
  			/* Find the right graphic rendition. */
 -			if (zero) {
--			    	gr = 0;
--			} else {
 +			//if (zero) {
-+			    	//gr = 0;
+ 			    	gr = 0;
+-			} else {
 +			//} else {
  				gr = sbp->gr;
  				if (!gr)
  					gr = field_ea->gr;
-@@ -2427,12 +2428,12 @@
- 					any_blink = True;
+@@ -2434,12 +2434,12 @@ draw_fields(union sp *buffer, int first, int last)
+ 					any_blink = true;
  				if (appres.highlight_bold && FA_IS_HIGH(fa))
  					gr |= GR_INTENSIFY;
 -			}
@@ -481,61 +420,57 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
 -			    	e_color = fa_color(FA_INT_HIGH_SEL);
 -			} else {
 +			//if (zero) {
-+			    	//e_color = fa_color(FA_INT_HIGH_SEL);
++			//    	e_color = fa_color(FA_INT_HIGH_SEL);
 +			//} else {
  				if (sbp->fg)
  					e_color = sbp->fg & COLOR_MASK;
- 				else if (appres.mono && (gr & GR_INTENSIFY))
-@@ -2443,16 +2444,22 @@
+ 				else if (appres.interactive.mono &&
+@@ -2452,16 +2452,20 @@ draw_fields(union sp *buffer, int first, int last)
  					e_color = INVERT_COLOR(e_color);
- 					reverse = True;
+ 					reverse = true;
  				}
 -			}
-+				if (zero) {
-+					e_color = INVERT_COLOR(e_color);
-+					reverse = True;
-+				}
 +			//}
- 			if (!appres.mono)
++            if (zero) {
++               e_color = INVERT_COLOR(e_color);
++               reverse = True;
++            }
+ 			if (!appres.interactive.mono)
  				b.bits.fg = e_color;
  
  			/* Find the right character and character set. */
  			d = ctlr_dbcs_state(baddr);
 -			if (zero) {
--				if (visible_control)
--					b.bits.cc = EBC_space;
--			} else if (((!visible_control || c != EBC_null) &&
 +			//if (zero) {
-+				//if (visible_control)
-+					//b.bits.cc = EBC_space;
-+					//b.bits.cc = EBC_period;
-+			//} else if (((!visible_control || c != EBC_null) &&
+ 				if (visible_control)
+ 					b.bits.cc = EBC_space;
+-			} else if (((!visible_control || c != EBC_null) &&
 +			if (((!visible_control || c != EBC_null) &&
  				    (c != EBC_space || d != DBCS_NONE)) ||
  			           (gr & (GR_REVERSE | GR_UNDERLINE)) ||
  				   visible_control) {
-@@ -2727,13 +2734,13 @@
+@@ -2736,13 +2740,13 @@ char_color(int baddr)
  	/*
  	 * For non-display fields, we ignore gr and fg.
  	 */
 -	if (FA_IS_ZERO(fa)) {
 -		color = fa_color(fa);
--		if (appres.mono && SELECTED(baddr)) {
+-		if (appres.interactive.mono && SELECTED(baddr)) {
 -			color = INVERT_COLOR(color);
 -		}
 -		return color;
 -	}
 +	//if (FA_IS_ZERO(fa)) {
-+		//color = fa_color(fa);
-+		//if (appres.mono && SELECTED(baddr)) {
-+			//color = INVERT_COLOR(color);
-+		//}
-+		//return color;
++	//	color = fa_color(fa);
++	//	if (appres.interactive.mono && SELECTED(baddr)) {
++	//		color = INVERT_COLOR(color);
++	//	}
++	//	return color;
 +	//}
  
  	/*
  	 * Find the color of the character or the field.
-@@ -2856,18 +2863,18 @@
+@@ -2864,13 +2868,13 @@ redraw_char(int baddr, bool invert)
  	if (d == DBCS_LEFT || d == DBCS_RIGHT)
  		buffer[0].bits.cs = CS_DBCS;
  	fa = ea_buf[faddr].fa;
@@ -543,7 +478,7 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
 -		gr = 0;
 -	} else {
 +	//if (FA_IS_ZERO(fa)) {
-+		//gr = 0;
++	//	gr = 0;
 +	//} else {
  		gr = ea_buf[baddr].gr;
  		if (!gr)
@@ -553,32 +488,27 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
  	if (ea_buf[baddr].fa) {
  		if (!visible_control)
  			blank_it = 1;
--	} else if (FA_IS_ZERO(fa)) {
--		blank_it = 1;
-+	//} else if (FA_IS_ZERO(fa)) {
-+		//blank_it = 1;
- 	} else if (text_blinkers_exist && !text_blinking_on) {
- 		if (gr & GR_BLINK)
- 			blank_it = 1;
-@@ -3526,10 +3533,10 @@
- 		/*
- 		 * Color indices are the intensity bits (0 through 2)
- 		 */
--		if (FA_IS_ZERO(fa) ||
--		    (appres.modified_sel && FA_IS_MODIFIED(fa)))
--			return GC_NONDEFAULT | FA_INT_NORM_SEL;
--		else
-+		//if (FA_IS_ZERO(fa) ||
-+		    //(appres.modified_sel && FA_IS_MODIFIED(fa)))
-+			//return GC_NONDEFAULT | FA_INT_NORM_SEL;
-+		//else
- 			return GC_NONDEFAULT | (fa & 0x0c);
- 	}
+@@ -3541,11 +3545,11 @@ fa_color(unsigned char fa)
+ 	/*
+ 	 * Color indices are the intensity bits (0 through 2)
+ 	 */
+-	if (FA_IS_ZERO(fa) || (appres.modified_sel && FA_IS_MODIFIED(fa))) {
+-	    return GC_NONDEFAULT | FA_INT_NORM_SEL;
+-	} else {
++	//if (FA_IS_ZERO(fa) || (appres.modified_sel && FA_IS_MODIFIED(fa))) {
++	//    return GC_NONDEFAULT | FA_INT_NORM_SEL;
++	//} else {
+ 	    return GC_NONDEFAULT | (fa & 0x0c);
+-	}
++	//}
+     }
  }
-diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
---- x3270-3.3/select.c	2013-07-12 00:03:27.000000000 +0200
-+++ x3270-3.3-hacked/select.c	2013-12-16 23:51:46.000000000 +0200
-@@ -234,18 +234,18 @@
+ 
+diff --git x3270/select.c x3270/select.c
+index 4753e0c..192eaf0 100644
+--- x3270/select.c
++++ x3270/select.c
+@@ -235,18 +235,18 @@ select_word(int baddr, Time t)
  	int class;
  
  	/* Find the initial character class */
@@ -586,7 +516,7 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -		ch = EBC_space;
 -	else
 +	//if (FA_IS_ZERO(fa))
-+		//ch = EBC_space;
++	//	ch = EBC_space;
 +	//else
  		ch = ea_buf[baddr].cc;
  	class = char_class[ebc2asc0[ch]];
@@ -598,12 +528,12 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -			ch = EBC_space;
 -		else
 +		//if (FA_IS_ZERO(fa))
-+			//ch = EBC_space;
++		//	ch = EBC_space;
 +		//else
  			ch = ea_buf[f_start].cc;
  		if (char_class[ebc2asc0[ch]] != class) {
  			f_start++;
-@@ -256,9 +256,9 @@
+@@ -257,9 +257,9 @@ select_word(int baddr, Time t)
  	/* Find the end */
  	for (f_end = baddr; (f_end+1) % COLS; f_end++) {
  		fa = get_field_attribute(f_end);
@@ -611,22 +541,22 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -			ch = EBC_space;
 -		else
 +		//if (FA_IS_ZERO(fa))
-+			//ch = EBC_space;
++		//	ch = EBC_space;
 +		//else
  			ch = ea_buf[f_end].cc;
  		if (char_class[ebc2asc0[ch]] != class) {
  			f_end--;
-@@ -820,7 +820,8 @@
- 	for (baddr = 0; baddr < ROWS*COLS; baddr++) {
- 		if (ea_buf[baddr].fa)
- 			fa = ea_buf[baddr].fa;
--		else if ((IN_ANSI || !FA_IS_PROTECTED(fa)) && SELECTED(baddr))
-+		//else if ((IN_ANSI || !FA_IS_PROTECTED(fa)) && SELECTED(baddr))
-+		else if (IN_ANSI && SELECTED(baddr))
- 			target[baddr/ULBS] |= 1 << (baddr%ULBS);
+@@ -863,7 +863,8 @@ Cut_xaction(Widget w _is_unused, XEvent *event, String *params,
+     for (baddr = 0; baddr < ROWS*COLS; baddr++) {
+ 	if (ea_buf[baddr].fa) {
+ 	    fa = ea_buf[baddr].fa;
+-	} else if ((IN_NVT || !FA_IS_PROTECTED(fa)) && screen_selected(baddr)) {
++	//} else if ((IN_NVT || !FA_IS_PROTECTED(fa)) && screen_selected(baddr)) {
++	} 	else if (IN_NVT && screen_selected(baddr))  {
+ 	    target[baddr/ULBS] |= 1L << (baddr%ULBS);
  	}
- 
-@@ -1239,10 +1240,10 @@
+     }
+@@ -1314,10 +1315,10 @@ onscreen_char(int baddr, unsigned char *r, int *rlen)
  	}
  
  	/* If it isn't visible, then make it a blank. */
@@ -635,9 +565,9 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -		return;
 -	}
 +	//if (FA_IS_ZERO(fa)) {
-+		//*r = ' ';
-+		//return;
++	//	*r = ' ';
++	//	return;
 +	//}
  
- #if defined(X3270_DBCS) /*[*/
  	/* Handle DBCS. */
+ 	switch (ctlr_dbcs_state(baddr)) {

--- a/x3270-hack-showhidden.patch
+++ b/x3270-hack-showhidden.patch
@@ -1,72 +1,36 @@
-diff -u x3270-3.3/fprint_screen.c x3270-3.3-hacked/fprint_screen.c
---- x3270-3.3/fprint_screen.c	2013-07-12 00:03:24.000000000 +0200
-+++ x3270-3.3-hacked/fprint_screen.c	2013-12-16 10:51:12.000000000 +0200
-@@ -464,14 +465,14 @@
- 				fa_high = FA_IS_HIGH(fa);
- 			fa_ital = mi && FA_IS_MODIFIED(fa);
- 		}
--		if (FA_IS_ZERO(fa)) {
--#if defined(X3270_DBCS) /*[*/
--			if (ctlr_dbcs_state(i) == DBCS_LEFT)
--			    	uc = 0x3000;
--			else
--#endif /*]*/
--				uc = ' ';
--		} else {
-+		//if (FA_IS_ZERO(fa)) {
-+//#if defined(X3270_DBCS) /*[*/
-+			//if (ctlr_dbcs_state(i) == DBCS_LEFT)
-+			    	//uc = 0x3000;
-+			//else
-+//#endif /*]*/
-+				//uc = ' ';
-+		//} else {
- 		    	/* Convert EBCDIC to Unicode. */
- #if defined(X3270_DBCS) /*[*/
- 			switch (ctlr_dbcs_state(i)) {
-@@ -503,7 +504,7 @@
- 			if (uc == 0)
- 				uc = ' ';
- #endif /*]*/
--		}
-+		//}
- 
- 		/* Translate to a type-specific format and write it out. */
- 		if (uc == ' ' && fps->ptype != P_HTML)
-diff -u x3270-3.3/macros.c x3270-3.3-hacked/macros.c
---- x3270-3.3/macros.c	2013-07-25 00:02:10.000000000 +0200
-+++ x3270-3.3-hacked/macros.c	2013-12-16 10:57:22.000000000 +0200
-@@ -2093,9 +2093,9 @@
- 			if (buf[first + i].fa) {
- 				is_zero = FA_IS_ZERO(buf[first + i].fa);
- 				s += sprintf(s, " ");
--			} else if (is_zero)
--				s += sprintf(s, " ");
--			else
-+			//} else if (is_zero) {
-+				//s += sprintf(s, " ");
-+			} else
- #if defined(X3270_DBCS) /*[*/
- 			if (IS_LEFT(ctlr_dbcs_state(first + i))) {
- 
-diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
---- x3270-3.3/screen.c	2013-09-06 16:59:02.000000000 +0200
-+++ x3270-3.3-hacked/screen.c	2013-12-16 23:42:49.000000000 +0200
-@@ -2417,9 +2418,9 @@
- 			Boolean is_vc = False;
+diff --git lib/3270/macros.c lib/3270/macros.c
+index 7cd1ab8..9c707c0 100644
+--- lib/3270/macros.c
++++ lib/3270/macros.c
+@@ -2205,8 +2205,8 @@ dump_range(int first, int len, bool in_ascii, struct ea *buf,
+ 	    if (buf[first + i].fa) {
+ 		is_zero = FA_IS_ZERO(buf[first + i].fa);
+ 		vb_appends(&r, " ");
+-	    } else if (is_zero) {
+-		vb_appends(&r, " ");
++	   // } else if (is_zero) {
++		//vb_appends(&r, " ");
+ 	    } else if (IS_LEFT(ctlr_dbcs_state(first + i))) {
+ 		xlen = ebcdic_to_multibyte(
+ 			(buf[first + i].cc << 8) | buf[first + i + 1].cc,
+diff --git x3270/screen.c x3270/screen.c
+index adbb4a9..ce2ab60 100644
+--- x3270/screen.c
++++ x3270/screen.c
+@@ -2424,9 +2424,9 @@ draw_fields(union sp *buffer, int first, int last)
+ 			bool is_vc = false;
  
  			/* Find the right graphic rendition. */
 -			if (zero) {
--			    	gr = 0;
--			} else {
 +			//if (zero) {
-+			    	//gr = 0;
+ 			    	gr = 0;
+-			} else {
 +			//} else {
  				gr = sbp->gr;
  				if (!gr)
  					gr = field_ea->gr;
-@@ -2427,12 +2428,12 @@
- 					any_blink = True;
+@@ -2434,12 +2434,12 @@ draw_fields(union sp *buffer, int first, int last)
+ 					any_blink = true;
  				if (appres.highlight_bold && FA_IS_HIGH(fa))
  					gr |= GR_INTENSIFY;
 -			}
@@ -77,61 +41,57 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
 -			    	e_color = fa_color(FA_INT_HIGH_SEL);
 -			} else {
 +			//if (zero) {
-+			    	//e_color = fa_color(FA_INT_HIGH_SEL);
++			//    	e_color = fa_color(FA_INT_HIGH_SEL);
 +			//} else {
  				if (sbp->fg)
  					e_color = sbp->fg & COLOR_MASK;
- 				else if (appres.mono && (gr & GR_INTENSIFY))
-@@ -2443,16 +2444,22 @@
+ 				else if (appres.interactive.mono &&
+@@ -2452,16 +2452,20 @@ draw_fields(union sp *buffer, int first, int last)
  					e_color = INVERT_COLOR(e_color);
- 					reverse = True;
+ 					reverse = true;
  				}
 -			}
-+				if (zero) {
-+					e_color = INVERT_COLOR(e_color);
-+					reverse = True;
-+				}
 +			//}
- 			if (!appres.mono)
++            if (zero) {
++               e_color = INVERT_COLOR(e_color);
++               reverse = True;
++            }
+ 			if (!appres.interactive.mono)
  				b.bits.fg = e_color;
  
  			/* Find the right character and character set. */
  			d = ctlr_dbcs_state(baddr);
 -			if (zero) {
--				if (visible_control)
--					b.bits.cc = EBC_space;
--			} else if (((!visible_control || c != EBC_null) &&
 +			//if (zero) {
-+				//if (visible_control)
-+					//b.bits.cc = EBC_space;
-+					//b.bits.cc = EBC_period;
-+			//} else if (((!visible_control || c != EBC_null) &&
+ 				if (visible_control)
+ 					b.bits.cc = EBC_space;
+-			} else if (((!visible_control || c != EBC_null) &&
 +			if (((!visible_control || c != EBC_null) &&
  				    (c != EBC_space || d != DBCS_NONE)) ||
  			           (gr & (GR_REVERSE | GR_UNDERLINE)) ||
  				   visible_control) {
-@@ -2727,13 +2734,13 @@
+@@ -2736,13 +2740,13 @@ char_color(int baddr)
  	/*
  	 * For non-display fields, we ignore gr and fg.
  	 */
 -	if (FA_IS_ZERO(fa)) {
 -		color = fa_color(fa);
--		if (appres.mono && SELECTED(baddr)) {
+-		if (appres.interactive.mono && SELECTED(baddr)) {
 -			color = INVERT_COLOR(color);
 -		}
 -		return color;
 -	}
 +	//if (FA_IS_ZERO(fa)) {
-+		//color = fa_color(fa);
-+		//if (appres.mono && SELECTED(baddr)) {
-+			//color = INVERT_COLOR(color);
-+		//}
-+		//return color;
++	//	color = fa_color(fa);
++	//	if (appres.interactive.mono && SELECTED(baddr)) {
++	//		color = INVERT_COLOR(color);
++	//	}
++	//	return color;
 +	//}
  
  	/*
  	 * Find the color of the character or the field.
-@@ -2856,18 +2863,18 @@
+@@ -2864,13 +2868,13 @@ redraw_char(int baddr, bool invert)
  	if (d == DBCS_LEFT || d == DBCS_RIGHT)
  		buffer[0].bits.cs = CS_DBCS;
  	fa = ea_buf[faddr].fa;
@@ -139,7 +99,7 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
 -		gr = 0;
 -	} else {
 +	//if (FA_IS_ZERO(fa)) {
-+		//gr = 0;
++	//	gr = 0;
 +	//} else {
  		gr = ea_buf[baddr].gr;
  		if (!gr)
@@ -149,32 +109,27 @@ diff -u x3270-3.3/screen.c x3270-3.3-hacked/screen.c
  	if (ea_buf[baddr].fa) {
  		if (!visible_control)
  			blank_it = 1;
--	} else if (FA_IS_ZERO(fa)) {
--		blank_it = 1;
-+	//} else if (FA_IS_ZERO(fa)) {
-+		//blank_it = 1;
- 	} else if (text_blinkers_exist && !text_blinking_on) {
- 		if (gr & GR_BLINK)
- 			blank_it = 1;
-@@ -3526,10 +3533,10 @@
- 		/*
- 		 * Color indices are the intensity bits (0 through 2)
- 		 */
--		if (FA_IS_ZERO(fa) ||
--		    (appres.modified_sel && FA_IS_MODIFIED(fa)))
--			return GC_NONDEFAULT | FA_INT_NORM_SEL;
--		else
-+		//if (FA_IS_ZERO(fa) ||
-+		    //(appres.modified_sel && FA_IS_MODIFIED(fa)))
-+			//return GC_NONDEFAULT | FA_INT_NORM_SEL;
-+		//else
- 			return GC_NONDEFAULT | (fa & 0x0c);
- 	}
+@@ -3541,11 +3545,11 @@ fa_color(unsigned char fa)
+ 	/*
+ 	 * Color indices are the intensity bits (0 through 2)
+ 	 */
+-	if (FA_IS_ZERO(fa) || (appres.modified_sel && FA_IS_MODIFIED(fa))) {
+-	    return GC_NONDEFAULT | FA_INT_NORM_SEL;
+-	} else {
++	//if (FA_IS_ZERO(fa) || (appres.modified_sel && FA_IS_MODIFIED(fa))) {
++	//    return GC_NONDEFAULT | FA_INT_NORM_SEL;
++	//} else {
+ 	    return GC_NONDEFAULT | (fa & 0x0c);
+-	}
++	//}
+     }
  }
-diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
---- x3270-3.3/select.c	2013-07-12 00:03:27.000000000 +0200
-+++ x3270-3.3-hacked/select.c	2013-12-16 10:56:16.000000000 +0200
-@@ -234,18 +234,18 @@
+ 
+diff --git x3270/select.c x3270/select.c
+index 4753e0c..3b4a3b9 100644
+--- x3270/select.c
++++ x3270/select.c
+@@ -235,18 +235,18 @@ select_word(int baddr, Time t)
  	int class;
  
  	/* Find the initial character class */
@@ -182,7 +137,7 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -		ch = EBC_space;
 -	else
 +	//if (FA_IS_ZERO(fa))
-+		//ch = EBC_space;
++	//	ch = EBC_space;
 +	//else
  		ch = ea_buf[baddr].cc;
  	class = char_class[ebc2asc0[ch]];
@@ -194,12 +149,12 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -			ch = EBC_space;
 -		else
 +		//if (FA_IS_ZERO(fa))
-+			//ch = EBC_space;
++		//	ch = EBC_space;
 +		//else
  			ch = ea_buf[f_start].cc;
  		if (char_class[ebc2asc0[ch]] != class) {
  			f_start++;
-@@ -256,9 +256,9 @@
+@@ -257,9 +257,9 @@ select_word(int baddr, Time t)
  	/* Find the end */
  	for (f_end = baddr; (f_end+1) % COLS; f_end++) {
  		fa = get_field_attribute(f_end);
@@ -207,12 +162,12 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -			ch = EBC_space;
 -		else
 +		//if (FA_IS_ZERO(fa))
-+			//ch = EBC_space;
++		//	ch = EBC_space;
 +		//else
  			ch = ea_buf[f_end].cc;
  		if (char_class[ebc2asc0[ch]] != class) {
  			f_end--;
-@@ -1239,10 +1240,10 @@
+@@ -1314,10 +1314,10 @@ onscreen_char(int baddr, unsigned char *r, int *rlen)
  	}
  
  	/* If it isn't visible, then make it a blank. */
@@ -221,9 +176,9 @@ diff -u x3270-3.3/select.c x3270-3.3-hacked/select.c
 -		return;
 -	}
 +	//if (FA_IS_ZERO(fa)) {
-+		//*r = ' ';
-+		//return;
++	//	*r = ' ';
++	//	return;
 +	//}
  
- #if defined(X3270_DBCS) /*[*/
  	/* Handle DBCS. */
+ 	switch (ctlr_dbcs_state(baddr)) {


### PR DESCRIPTION
x3270 3.4ga9 was significantly different from the version originally used for birp. This update fixes the patch files for the current version of x3270. 